### PR TITLE
new test to prove that the chdir back to a renamed directory works

### DIFF
--- a/t/02_renamed.t
+++ b/t/02_renamed.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Cwd qw/getcwd/;
+use Cwd::Guard qw/cwd_guard/;
+use File::Temp qw/tempdir/;
+
+plan skip_all => "Safe renames only possible with fchdir"
+    if !Cwd::Guard::USE_FCHDIR;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $olddir = "$tempdir/foo";
+my $newdir = "$tempdir/bla";
+mkdir $olddir;
+chdir $olddir or die $!;
+
+{
+    my $guard = cwd_guard $tempdir;
+    rename $olddir, $newdir or die $!;
+}
+
+is getcwd, $newdir, 'can change back to renamed directory';
+
+chdir '/'; # so tempdir can do a cleanup
+
+done_testing;
+
+__END__


### PR DESCRIPTION
I think this is a cool feature of Cwd::Guard, and should probably be advertized also in the Pod, as a unique point against File::pushd and File::chdir.
